### PR TITLE
Change server.json to listen for DNS on 0.0.0.0

### DIFF
--- a/datacenter-deploy-service-discovery/server.json
+++ b/datacenter-deploy-service-discovery/server.json
@@ -9,7 +9,8 @@
     "data_dir": "/consul/data",
     "log_level":"INFO",
     "addresses": {
-        "http" : "0.0.0.0"
+        "http" : "0.0.0.0",
+        "dns" : "0.0.0.0"
     },
     "service": {
         "id": "dns",


### PR DESCRIPTION
With no `client_addr` or `addresses.dns` entry, the DNS server won't be accessible outside of the Docker container it's running in, which I don't think was the way this was intended.